### PR TITLE
Fix #2: show non-string results in Pyodide.eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,10 @@ async function run(code) {
 
         if (typeof rslt === 'string') {
             send.lia(rslt)
+        } else if (rslt && typeof rslt.toString === 'function') {
+            send.lia(rslt.toString());
         }
+
     } catch(e) {
         let module = e.message.match(/ModuleNotFoundError: The module '([^']+)/i)
 


### PR DESCRIPTION
as already discussed in #2
this makes the results of Pyodide.eval more consistent by showing all results that can be converted to strings -- not only the results that are already of type string.