### PR TITLE
Unify eval and exec handling, and improve error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ comment:  Use the real Python in your LiaScript courses, by loading this
 script:   https://cdn.jsdelivr.net/pyodide/v0.27.3/full/pyodide.js
 
 @onload
-async function runPython(code, io, targetId) {
-    const plot = document.getElementById(targetId)
+async function runPython(code, io) {
+    const plot = document.getElementById(io.mplout)
     plot.innerHTML = ""
     document.pyodideMplTarget = plot
 
@@ -79,10 +79,11 @@ async function run_exec() {
             stderr: (text) => console.error(text),
             liaout: send.lia,
             liaerr: send.lia,
-            clearOut: true
+            clearOut: true,
+            mplout: "target_@0"
         }
 
-        await window.runPython(code, io, "target_@0")
+        await window.runPython(code, io)
     } else {
         setTimeout(run_exec, 1000)
     }
@@ -124,10 +125,11 @@ async function run_eval() {
         },
         liaout: send.lia,
         liaerr: console.error,
-        clearOut: false
+        clearOut: false,
+        mplout: "target_@0"
     }
 
-    await window.runPython(code, io, "target_@0")
+    await window.runPython(code, io)
 }
 
 if (window.pyodide_running) {

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ async function runPython(code, io) {
             io.liaout("")
         }
     } catch (e) {
-        io.liaout(e.message)
+        io.liaerr(e.message)
     }
     io.liaout("LIA: stop")
     window.pyodide_running = false
@@ -78,7 +78,7 @@ async function run_exec() {
             stdout: (text) => console.log(text),
             stderr: (text) => console.error(text),
             liaout: send.lia,
-            liaerr: send.lia,
+            liaerr: (text) => send.lia(text, false),
             clearOut: true,
             mplout: "target_@0"
         }

--- a/README.md
+++ b/README.md
@@ -278,21 +278,7 @@ plt.show()
                                    --{{0}}--
 
 Only the Python standard library and `six` are available at the beginning, other
-libraries are globally loaded, if defined within the script. If you know, that certain modules are required, you can speed up their loading by defining them
-manually in your `onload` macro, as it is shown below.
-
-
-``` markdown
-<!--
-author:  ...
-email:   ...
-
-import:  https://github.com/LiaTemplates/Pyodide
-
-@onload: window.py_packages = ["matplotlib", "numpy"]
--->
-...
-```
+libraries are globally loaded, if defined within the script.
 
 > __Note:__ loading large packages such as `scipy` may take some time, since
 >           they might require to download many MB of precompiled packages.

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ window.runPython = runPython
 <script run-once modify="# --python--\n" type="text/python">
 
 async function run_exec() {
-    const code = `# --python--
-@'1
+    const code = String.raw`# --python--
+@1
 # --python--
 `
     if (!window.pyodide_running) {

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ async function runPython(code, io, targetId) {
             io.liaout(rslt)
         } else if (rslt !== undefined && typeof rslt.toString === 'function') {
             io.liaout(rslt.toString())
-        } else {
+        } else if (io.clearOut) {
             io.liaout("")
         }
     } catch (e) {
@@ -78,7 +78,8 @@ async function run_exec() {
             stdout: (text) => console.log(text),
             stderr: (text) => console.error(text),
             liaout: send.lia,
-            liaerr: send.lia
+            liaerr: send.lia,
+            clearOut: true
         }
 
         await window.runPython(code, io, "target_@0")
@@ -122,7 +123,8 @@ async function run_eval() {
             }
         },
         liaout: send.lia,
-        liaerr: console.error
+        liaerr: console.error,
+        clearOut: false
     }
 
     await window.runPython(code, io, "target_@0")

--- a/README.md
+++ b/README.md
@@ -19,49 +19,53 @@ async function run_exec(code, localSend, targetId) {
     if (!window.pyodide_running) {
         window.pyodide_running = true
 
-        const plot = document.getElementById(targetId)
-        plot.innerHTML = ""
-        document.pyodideMplTarget = plot
-
-        if (!window.pyodide) {
-            try {
-                window.pyodide = await loadPyodide({ fullStdLib: false });
-                window.pyodide_modules = []
-                window.pyodide_running = true
-            } catch (e) {
-                localSend.lia(e.message, false)
-                localSend.lia("LIA: stop")
-            }
-        }
-
-        try {
-            window.pyodide.setStdout((text) => console.log(text))
-            window.pyodide.setStderr((text) => console.error(text))
-
-            window.pyodide.setStdin({
-                stdin: () => {
-                    return prompt("stdin")
-                }
-            })
-
-            window.pyodide.loadPackagesFromImports(code).then(async () => {
-                const rslt = await window.pyodide.runPython(code)
-
-                if (rslt !== undefined) {
-                    localSend.lia(rslt)
-                } else {
-                    localSend.lia("")
-                }
-            });
-
-        } catch (e) {
-            console.error(e.message)
-        }
-        localSend.lia("LIA: stop")
-        window.pyodide_running = false
+        await run_exec_inner(code, localSend, targetId)
     } else {
         setTimeout(() => { run_exec(code, localSend, targetId) }, 1000)
     }
+}
+
+async function run_exec_inner(code, localSend, targetId) {
+    const plot = document.getElementById(targetId)
+    plot.innerHTML = ""
+    document.pyodideMplTarget = plot
+
+    if (!window.pyodide) {
+        try {
+            window.pyodide = await loadPyodide({ fullStdLib: false });
+            window.pyodide_modules = []
+            window.pyodide_running = true
+        } catch (e) {
+            localSend.lia(e.message, false)
+            localSend.lia("LIA: stop")
+        }
+    }
+
+    try {
+        window.pyodide.setStdout((text) => console.log(text))
+        window.pyodide.setStderr((text) => console.error(text))
+
+        window.pyodide.setStdin({
+            stdin: () => {
+                return prompt("stdin")
+            }
+        })
+
+        window.pyodide.loadPackagesFromImports(code).then(async () => {
+            const rslt = await window.pyodide.runPython(code)
+
+            if (rslt !== undefined) {
+                localSend.lia(rslt)
+            } else {
+                localSend.lia("")
+            }
+        });
+
+    } catch (e) {
+        console.error(e.message)
+    }
+    localSend.lia("LIA: stop")
+    window.pyodide_running = false
 }
 
 async function run_eval(code, localSend, localConsole, targetId) {

--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ async function run_exec() {
         window.pyodide_running = true
 
         const io = {
-            stdout: (text) => console.log(text),
-            stderr: (text) => console.error(text),
+            stdout: {batched: console.log},
+            stderr: {batched: console.error},
             liaout: send.lia,
             liaerr: (text) => send.lia(text, false),
             clearOut: true,

--- a/README.md
+++ b/README.md
@@ -40,18 +40,16 @@ async function runPython(code, io, targetId) {
             }
         })
 
-        window.pyodide.loadPackagesFromImports(code).then(async () => {
-            const rslt = await window.pyodide.runPython(code)
+        await window.pyodide.loadPackagesFromImports(code)
+        const rslt = await window.pyodide.runPythonAsync(code)
 
-            if (typeof rslt === 'string') {
-                io.liaout(rslt)
-            } else if (rslt !== undefined && typeof rslt.toString === 'function') {
-                io.liaout(rslt.toString())
-            } else {
-                io.liaout("")
-            }
-        });
-
+        if (typeof rslt === 'string') {
+            io.liaout(rslt)
+        } else if (rslt !== undefined && typeof rslt.toString === 'function') {
+            io.liaout(rslt.toString())
+        } else {
+            io.liaout("")
+        }
     } catch (e) {
         io.liaout(e.message)
     }

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ window.runPython = runPython
 <script run-once modify="# --python--\n" type="text/python">
 
 async function run_exec() {
-    const code = `# --python--
+    const code = String.raw`# --python--
 @1
 # --python--
 `
@@ -103,7 +103,7 @@ setTimeout(run_exec, 500)
 <script>
 
 async function run_eval() {
-    const code = `@input`
+    const code = String.raw`@input`
     const io = {
         stdout: {
             write: (buffer) => {

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ window.runPython = runPython
 <script run-once modify="# --python--\n" type="text/python">
 
 async function run_exec() {
-    const code = String.raw`# --python--
-@1
+    const code = `# --python--
+@'1
 # --python--
 `
     if (!window.pyodide_running) {
@@ -105,7 +105,7 @@ setTimeout(run_exec, 500)
 <script>
 
 async function run_eval() {
-    const code = String.raw`@input`
+    const code = "@'input"
     const io = {
         stdout: {
             write: (buffer) => {

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ script:   https://cdn.jsdelivr.net/pyodide/v0.27.3/full/pyodide.js
 @Pyodide.exec: @Pyodide.exec_(@uid,```@0```)
 
 @Pyodide.exec_
-<script run-once modify="# --python--\n">
+<script run-once modify="# --python--\n" type="text/python">
 async function run_exec(code, force = false) {
     if (!window.pyodide_running || force) {
         window.pyodide_running = true

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ async function runPython(code, io, targetId) {
     try {
         window.pyodide.setStdout(io.stdout)
         window.pyodide.setStderr(io.stderr)
-
         window.pyodide.setStdin({
             stdin: () => {
                 return prompt("stdin")
@@ -132,16 +131,16 @@ async function run_eval() {
 }
 
 if (window.pyodide_running) {
-  setTimeout(() => {
-    console.warn("Another process is running, wait until finished")
-  }, 500)
-  "LIA: stop"
+    setTimeout(() => {
+        console.warn("Another process is running, wait until finished")
+    }, 500)
+
+    "LIA: stop"
 } else {
-  window.pyodide_running = true
+    window.pyodide_running = true
+    setTimeout(run_eval, 500)
 
-  setTimeout(run_eval, 500)
-
-  "LIA: wait"
+    "LIA: wait"
 }
 </script>
 

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ script:   https://cdn.jsdelivr.net/pyodide/v0.24.0/full/pyodide.js
 async function run(code, force=false) {
     if (!window.pyodide_running || force) {
         window.pyodide_running = true
-    
+
         const plot = document.getElementById('target_@0')
         plot.innerHTML = ""
         document.pyodideMplTarget = plot
@@ -357,9 +357,9 @@ async function run(code, force=false) {
             window.pyodide.setStdin({stdin: () => {
             return prompt("stdin")
             }})
-        
+
             const rslt = await window.pyodide.runPython(code)
-            
+
             if (rslt !== undefined) {
                 send.lia(rslt)
             } else {
@@ -369,10 +369,10 @@ async function run(code, force=false) {
             let module = e.message.match(/ModuleNotFoundError: No module named '([^']+)/i)
 
             window.console.warn("Pyodide", e.message)
-        
+
             if (!module) {
                 send.lia(e.message, false)
-            
+
             } else {
                 if (module.length > 1) {
                     module = module[1]
@@ -444,8 +444,8 @@ async function run(code) {
 
         window.pyodide.setStdin({stdin: () => {
           return prompt("stdin")
-        }}) 
-       
+        }})
+
         const rslt = await window.pyodide.runPython(code)
 
         if (typeof rslt === 'string') {
@@ -455,7 +455,7 @@ async function run(code) {
         let module = e.message.match(/ModuleNotFoundError: No module named '([^']+)/i)
 
         window.console.warn("Pyodide", e.message)
-    
+
         if (!module) {
             const err = e.message.match(/File "<exec>", line (\d+).*\n((.*\n){1,3})/i)
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ comment:  Use the real Python in your LiaScript courses, by loading this
 script:   https://cdn.jsdelivr.net/pyodide/v0.27.3/full/pyodide.js
 
 @onload
-async function run_exec(code, localSend, targetId, force = false) {
-    if (!window.pyodide_running || force) {
+async function run_exec(code, localSend, targetId) {
+    if (!window.pyodide_running) {
         window.pyodide_running = true
 
         const plot = document.getElementById(targetId)

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ async function runPython(code, io, targetId) {
     if (!window.pyodide) {
         try {
             window.pyodide = await loadPyodide({ fullStdLib: false });
-            window.pyodide_modules = []
             window.pyodide_running = true
         } catch (e) {
-            io.liaerr(e.message, false)
+            io.liaerr(e.message)
             io.liaout("LIA: stop")
+            return
         }
     }
 


### PR DESCRIPTION
Apologies for dropping a big PR here, without any discussion.  I started with the intention of getting Python error reporting working.  But in the process of figuring out the code to solve that, I saw some other possible improvement, and I couldn't resist.  As a result, this is a fairly massive change.  I've tried to structure the commits sensibly, so you have a hope of understanding my thought process.  I can try to split this up into multiple PRs, if you prefer, but I don't think there's a huge advantage to that.  Some of the changes in the early commits were never intended as permanent; they were just setting things up for later changes.

## Main Architectural Changes

1. The installPackagesManually_* functions have been removed.  I couldn't manage to trigger them to run when importing non-existent packages.  The `pyodid.loadPackageFromImports` worked for all the real packages I tried.  Even if they had run, I don't think they would have worked.  Each of them referenced the local variable `code`, which wasn't defined.
2. Unify the code to actually run Python code, from `run_exec` and `run_eval`.  These were pretty similar, but they had a couple of differences that looked accidental.  (Figuring out whether to display the output of a code cell, for example.)  Combining them should help enforce consistency.  The new function, `runPython` is defined in an `@onload` macro, so it's ready for use in the others.  This did require a bit of dancing to get local copies of `console` and `send` into the function for output, but in the end I think it wasn't too bad.
3. Use only await, getting rid of Promise.then.  This seems to have fixed the error reporting.

## Bug Fixes and Improvements

1. Python error are reported in the LiaScript UI, instead of the browser console.
2. Falsey values (other than None) are printed as the output of eval.
3. Numpy arrays are properly displaced as the output of exec.
4. Escape sequences in Python source code are passed into Pyodide, not eaten by Javascript.
5. Early exit if Pyodide fails to load.

I've put together a LiaScript document to test these and other behaviors:
- Running against [LiaScript/master](https://liascript.github.io/course/?https://gist.githubusercontent.com/rschroll/d9804a8191561326bcdc43b324de38b4/raw/d103c242b694832e65882570febd025d813e5488/Pyodide-master.md#18)
- Running against [this branch](https://liascript.github.io/course/?https://gist.githubusercontent.com/rschroll/d9804a8191561326bcdc43b324de38b4/raw/d103c242b694832e65882570febd025d813e5488/rschroll-simplify.md#18)

There's still some bad behavior, especially around stdout and stderr, as well as a bug if they Python source has a JS template expression in it.  I have some ideas of how to address these, but I thought it would be better to keep this PR from getting any larger.

I hope this makes some sense.  Do let me know if you have questions, or if you'd like something done differently!