### PR TITLE
Improve error reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ async function loadPython() {
                 frames = traceback.extract_tb(sys.last_traceback)
                 lines = [(frame.lineno, frame.colno) for frame in frames if frame.filename == '<exec>']
             return summary, lines
+
+        def _lia_flush_streams():
+            import sys
+
+            sys.stdout.flush()
+            sys.stderr.flush()
     `)
     return pyodide
 }
@@ -77,6 +83,7 @@ async function runPython(code, io) {
             io.liaerr(e.message)
         }
     }
+    await window.pyodide.runPythonAsync("_lia_flush_streams()")
     io.liaout("LIA: stop")
     window.pyodide_running = false
 }
@@ -143,7 +150,7 @@ async function run_eval() {
             write: (buffer) => {
                 const decoder = new TextDecoder()
                 const string = decoder.decode(buffer)
-                console.error(string)
+                send.log("error", '', [string])
                 return buffer.length
             }
         },


### PR DESCRIPTION
I saw that errors and warnings can be created on individual lines in the interactive code blocks.  I wanted that for Python, too.  It might be possible by parsing the tracebacks as strings, but it seemed easier to me to let Python tell us about the exception.  This creates a new Python function `_lia_process_exception`, which we call if a PythonError was raised during evaluation.  This gives us an error summary and a list of (line, col) pairs showing where the error occurred.  These are used to format the error information in a `send.lia` call.  The deepest call in the code is marked as an error.  Higher places on the call stack in our code are marked as warnings.

I would have preferred to deliver the error information in an object, rather than a list.  But when I tried that, I kept getting Proxy objects from Pyodide, rather than pure JS objects.  The Pyodide docs warn about memory leaks from these proxies, and I didn't want to worry about those.

From what I can tell, the exec mode doesn't have this capability.  But we can still make the traceback more readable by sticking it in a <pre>.

Because it's related in implementation, there's also some code in here to flush stderr and stdout at the end of execution.  This keeps us from having output stuck in one of those streams from one cell, then appearing as output in the next cell that's run.